### PR TITLE
feat(mmc): add temporary strings for the MMC

### DIFF
--- a/en.json
+++ b/en.json
@@ -931,6 +931,17 @@
         "Exiting.SavingChanges" : "Saving Changes...",
         "Exiting.Exiting" : "Exiting...",
         "Exiting.LoggingOut" : "Logging out...",
+        
+        "Temporary.MMC.Voting UI": "MMC Voting UI",
+        "Temporary.MMC.Vote": "Vote",
+        "Temporary.MMC.Categories.Name": "Categories",
+        "Temporary.MMC.Categories.Worlds": "Worlds",
+        "Temporary.MMC.Categories.Other": "Gadgets/Tools+",
+        "Temporary.MMC.Categories.Avatars": "Avatars",
+        "Temporary.MMC.VoteSuccess": "Vote cast in category {category} for {voteTarget}.",
+        "Temporary.MMC.VoteFailure": "Vote failed, your vote has not been registered please try again.",
+        "Temporary.MMC.VotedAlready": "You have already voted in {category}.",
+        "Temporary.MMC.VoteInvalid": "Vote is invalid, please try again.",
 
         "Dummy" : "Dummy"
     }


### PR DESCRIPTION
These are the temporary strings for the MMC, some of these look generically useful for the main Locale DB though. Such as the categories. 

Once they are translated they will be preserved within the Git history of this repo forever so we can always recycle them.