### PR TITLE
Minor Edit, Typo Corrections

### DIFF
--- a/de.json
+++ b/de.json
@@ -888,7 +888,7 @@
         "Settings.Audio.DisableVoiceNormalization" : "Keine Sprachlautstärke-Normalisierung",
         "Settings.Audio.NoiseGateThreshold" : "Hintergrundlautstärke-Grenzwert: {n}",
         "Settings.Audio.NormzliationThreshold" : "Normalisierungs-Grenzwert: {n}",
-        "Settings.Audio.NoiseSupression" : "Noise Supression Filter (RNNoise)",
+        "Settings.Audio.NoiseSupression" : "Noise Suppression Filter (RNNoise)",
         "Settings.Audio.InputDevice" : "Aufnahmegerät:",
         "Settings.Audio.SelectInputDevice" : "Aufnahmegerät wählen",
         "Settings.Audio.TestInput" : "Testen Sie Ihr Mikrofon:",

--- a/en.json
+++ b/en.json
@@ -889,7 +889,7 @@
         "Settings.Audio.DisableVoiceNormalization" : "Disable Voice Normalization",
         "Settings.Audio.NoiseGateThreshold" : "Noise Gate Threshold: {n}",
         "Settings.Audio.NormzliationThreshold" : "Normalization Threshold: {n}",
-        "Settings.Audio.NoiseSupression" : "Noise Supression Filter (RNNoise)",
+        "Settings.Audio.NoiseSupression" : "Noise Suppression Filter (RNNoise)",
         "Settings.Audio.InputDevice" : "Audio Input Device:",
         "Settings.Audio.SelectInputDevice" : "Select Audio Input Device",
         "Settings.Audio.TestInput" : "Test your audio input:",

--- a/en.json
+++ b/en.json
@@ -1,6 +1,6 @@
 {
     "localeCode" : "en",
-    "authors" : ["Frooxius", "Enverex", "rampa_3", "Melnus"],
+    "authors" : ["Frooxius", "Enverex", "rampa_3", "Melnus", "dfgHiatus"],
     "messages" : 
     {
         "General.OK" : "OK",


### PR DESCRIPTION
I was introducing a new user to NeosVR when they pointed out the spelling of "Suppression" was wrong in the settings ("Supression" vs. "Suppression"). 

I have updated the EN and DE locales accordingly, the same ought to be done for "Settings.Audio.NoiseSupression" => "Settings.Audio.NoiseSuppression".